### PR TITLE
Improve celery beat scheduler startup

### DIFF
--- a/supervisor/supervisor.conf
+++ b/supervisor/supervisor.conf
@@ -84,7 +84,7 @@ stopasgroup=true
 priority=1000
 
 [program:ontask-beat-celery]
-command=%(ENV_CELERY_BIN)s beat -A ontask --loglevel=INFO
+command=/bin/bash -c "rm -f %(ENV_PROJECT_PATH)s/src/celerybeat.pid && %(ENV_CELERY_BIN)s beat -A ontask --loglevel=INFO"
 directory=%(ENV_PROJECT_PATH)s/src
 ;user=nobody
 numprocs=1


### PR DESCRIPTION
Will now remove an existing `celerybeat.pid` on startup (this can happen if the scheduler doesn't clean up on termination due to errors/force stopping)