### PR TITLE
Add Canvas Oauth Scopes

### DIFF
--- a/src/ontask_oauth/views.py
+++ b/src/ontask_oauth/views.py
@@ -63,6 +63,7 @@ def get_initial_token_step1(request, oauth_info, return_url):
                              'client_id': oauth_info['client_id'],
                              'response_type': 'code',
                              'redirect_uri': request.session[callback_url_key],
+                             'scopes':'url:POST|/api/v1/conversations',
                              'state': request.session[oauth_hash_key],
                          }).prepare().url
     )


### PR DESCRIPTION
Needed to be declared if the developer key limites to scopes (https://canvas.instructure.com/doc/api/file.developer_keys.html). If scopes are not present, will automatically give full access (so its a good idea to self limit yourself if not required anyways).