### PR TITLE
Fix Canvas messages

### DIFF
--- a/src/action/send/canvasemail.py
+++ b/src/action/send/canvasemail.py
@@ -86,7 +86,7 @@ def send_canvas_emails(
         # https://canvas.instructure.com/doc/api/conversations.html
         #
         canvas_email_payload = {
-            'recipients[]': msg_to,
+            'recipients[]': int(msg_to),
             'body': msg_body,
             'subject': msg_subject,
         }

--- a/src/action/views/run_canvas_email.py
+++ b/src/action/views/run_canvas_email.py
@@ -76,6 +76,8 @@ def run_canvas_email_action(
 
             return redirect('action:item_filter')
 
+        set_action_payload(req.session, action_info.get_store())
+
         # Go straight to the token request step
         return canvas_get_or_set_oauth_token(
             req,

--- a/src/ontask_oauth/views.py
+++ b/src/ontask_oauth/views.py
@@ -130,7 +130,7 @@ def callback(request):
     :return: Redirection to the stored page
     """
     # Get the payload from the session
-    payload = get_action_payload(request)
+    payload = get_action_payload(request.session)
 
     # If there is no payload, something went wrong.
     if payload is None:


### PR DESCRIPTION
- should pass `request.session` instead of `request` to get_action_payload
- the target_url wasn't available for me when checking the session info. I believe this is due to having only one item in `CANVAS_INFO_DICT` (so the form field isn't present and target_url is added afterwards). forcing a `set_action_payload` before returning fixes this for me

fixes #151