### PR TITLE
Handle LTI launch roles

### DIFF
--- a/ontask/core/views.py
+++ b/ontask/core/views.py
@@ -35,7 +35,7 @@ def entry(request: HttpRequest) -> HttpResponse:
 
 @csrf_exempt
 @xframe_options_exempt
-@lti_role_required(['Instructor', 'Student'])
+@lti_role_required(['Instructor', 'Learner'])
 def lti_entry(request: HttpRequest) -> HttpResponse:
     """Enter the application through LTI."""
     return redirect('home')

--- a/ontask/settings/base.py
+++ b/ontask/settings/base.py
@@ -556,6 +556,8 @@ EMAIL_ACTION_PIXEL = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC' \
 #
 ###############################################################################
 LTI_OAUTH_CREDENTIALS = env.dict('LTI_OAUTH_CREDENTIALS', default={})
+LTI_INSTRUCTOR_GROUP_ROLES = env.list('LTI_INSTRUCTOR_GROUP_ROLES',
+    default=['Instructor'])
 
 ###############################################################################
 #


### PR DESCRIPTION
Added env variable LTI_INSTRUCTOR_GROUP_ROLES which stores a list of roles that should be automatically added to the instructor on LTI launch
Also changed `Student` to `Learner` in views.lti_entry since LTI launch roles for students is Learner

Closes #154