### PR TITLE
Force new canvas conversations

### DIFF
--- a/ontask/action/send/canvasemail.py
+++ b/ontask/action/send/canvasemail.py
@@ -89,6 +89,7 @@ def send_canvas_emails(
             'recipients[]': int(msg_to),
             'body': msg_body,
             'subject': msg_subject,
+            'force_new': True,
         }
 
         # Manage the bursts


### PR DESCRIPTION
Ensure that each canvas conversation sent by ontask is treated as a new conversation (will use the new subject properly and appear separately in the UI) instead of being grouped together under existing private conversations.