### PR TITLE
Drop kombu version from 4.6.5 to 4.6.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -74,7 +74,7 @@ jdcal==1.4.1
 jedi==0.15.1
 jsonschema==3.1.1
 jupyter-client==5.3.4
-kombu==4.6.5
+kombu==4.6.3
 lxml==4.4.1
 meld3==2.0.0
 mistune==0.8.4


### PR DESCRIPTION
Fixes celery error:
```
kombu.exceptions.OperationalError:
Cannot route message for exchange 'reply.celery.pidbox': Table empty or key no longer exists.
Probably the key ('_kombu.binding.reply.celery.pidbox') has been removed from the Redis database.
```

related to https://github.com/celery/kombu/issues/1063 (could be fixed in the near future with version 4.6.6)