### PR TITLE
Fix canvas conversations logging

### DIFF
--- a/ontask/action/send/canvasemail.py
+++ b/ontask/action/send/canvasemail.py
@@ -69,7 +69,6 @@ def send_canvas_emails(
 
     # Create the context for the log events
     context = {
-        'user': user.id,
         'action': action.id,
     }
 


### PR DESCRIPTION
192bd78d refactored logging but missed removing the user field from the context used for logging canvas conversations (causes error `Error: log() got multiple values for argument 'user'`)