### PR TITLE
Fix 0011_refresh_query_builder_ops migration

### DIFF
--- a/ontask/migrations/0011_refresh_query_builder_ops.py
+++ b/ontask/migrations/0011_refresh_query_builder_ops.py
@@ -18,9 +18,9 @@ def _adjust_boolean_operand(node):
         if node['input'] == 'radio':
             node['input'] = 'select'
 
-        if node['value'] == '1':
+        if node['value'] == '1' or node['value'] == True:
             node['value'] = 'true'
-        elif node['value'] == '0':
+        elif node['value'] == '0' or node['value'] == False:
             node['value'] = 'false'
         else:
             raise Exception('Incorrect formula found in migration.')


### PR DESCRIPTION
`Incorrect formula found in migration.` error thrown on some production data. Handling boolean values seems to have solved it.

Not sure how boolean values got in there (might be really old conditions). Just pushing this back in case anyone else runs into this.