### PR TITLE
refactor!: drop client_encoding argument for incompatibility with mysql dialect

### DIFF
--- a/ontask/dataops/pandas/database.py
+++ b/ontask/dataops/pandas/database.py
@@ -80,12 +80,7 @@ def create_db_engine(
         engine_url,
         echo=False,
         paramstyle='format',
-        connect_args=
-            {
-                'connect_timeout': 300,
-                'client_encoding': 'utf8',
-            }
-        )
+        connect_args={'connect_timeout': 300})
 
 
 def destroy_db_engine(db_engine=None):

--- a/ontask/dataops/pandas/database.py
+++ b/ontask/dataops/pandas/database.py
@@ -78,10 +78,14 @@ def create_db_engine(
 
     return sqlalchemy.create_engine(
         engine_url,
-        client_encoding=str('utf8'),
         echo=False,
         paramstyle='format',
-        connect_args={'connect_timeout': 300})
+        connect_args=
+            {
+                'connect_timeout': 300,
+                'client_encoding': 'utf8',
+            }
+        )
 
 
 def destroy_db_engine(db_engine=None):


### PR DESCRIPTION
### Description
This PR drops `client_encoding` keyword argument in favor of the default sqlalchemy configuration, since client_encoding SQLAlchemy psycopg2 dialect: https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#psycopg2-connect-arguments

Without this change, an error was raised when connecting to a MySQL database:
![image](https://github.com/abelardopardo/ontask_b/assets/64440265/65095d70-3faa-4b58-b399-b58a67c2241c)

I'm open to suggestions about these changes. Let me know!

### How to test
1. Create a SQL connection with these configurations:


2. Create an empty workflow
3. Upload data to the workflow by selecting the SQL configuration you created beforehand



I tested this change with MySQL and Postgres DBSM. 
